### PR TITLE
set multi-platform docker build (arm64 arch support)

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -14,6 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
       - name: Publish to Registry
         uses: elgohr/Publish-Docker-Github-Action@v5
         with:
@@ -21,6 +23,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ github.token }}
           registry: ghcr.io
+          platforms: linux/amd64,linux/arm64
 
   robokit-deploy:
     needs: build


### PR DESCRIPTION
as per the following documentation, we need to enable arm64 architecture support: https://github.com/elgohr/Publish-Docker-Github-Action?tab=readme-ov-file#platforms